### PR TITLE
Fix Tags dropdown button alignment in Modules table

### DIFF
--- a/src/Components/PreviewBox_main.js
+++ b/src/Components/PreviewBox_main.js
@@ -992,7 +992,8 @@ function PreviewBoxes_main_modules({
                                 textOverflow: "ellipsis",
                                 display: "flex",
                                 justifyContent: "center", // Center tags horizontally
-                                alignItems: "center"
+                                alignItems: "center",
+                                width: "100%" // Ensure full width
                               }}
                               className="column column-small  "
                               onClick={() =>
@@ -1008,24 +1009,24 @@ function PreviewBoxes_main_modules({
                               ) : null}
                               {/* ? (<p className='ml-a    font-type-txt   Color-Red   '> Undefined  </p> ) : null  } */}
                               {Info?.arguments?.tags?.length == 0 ? (
-                                <p className="font-type-txt tagit_type1">
+                                <p className="font-type-txt tagit_type1" style={{ textAlign: "center", width: "100%" }}>
                                   No Tags
                                 </p>
                               ) : null}
                               {Info?.arguments?.tags?.length === 1 ? (
                                 <p
                                   className="font-type-txt Color-Blue-Glow tagit_type1 cutLongLine"
-                                  style={{ maxWidth: "80%" }}
+                                  style={{ maxWidth: "80%", textAlign: "center" }}
                                 >
                                   {Info?.arguments?.tags[0]}
                                 </p>
                               ) : null}
                               {Info?.arguments?.tags?.length > 1 ? (
                                 <>
-                                  <p className="font-type-txt Color-Blue-Glow tagit_type1">
+                                  <p className="font-type-txt Color-Blue-Glow tagit_type1" style={{ textAlign: "center" }}>
                                     {Info?.arguments?.tags[0]}
                                   </p>{" "}
-                                  <p className="ml-a font-type-txt Color-Grey1">
+                                  <p className="ml-a font-type-txt Color-Grey1" style={{ textAlign: "center" }}>
                                     +{Info?.arguments?.tags?.length - 1}
                                   </p>
                                 </>

--- a/src/Components/PreviewBox_main.js
+++ b/src/Components/PreviewBox_main.js
@@ -681,8 +681,8 @@ function PreviewBoxes_main_modules({
                           className={`btn-type2 "btn-type2-no_btn"`}
                           onClick={() => setDropdownTagsShow(!DropdownTagsShow)}
                           style={{
-                            minWidth: "115px",
-                            maxWidth: "122px",
+                            minWidth: "140px",  // Changed from 115px to better fill the cell
+                            maxWidth: "145px",  // Changed from 122px to better fill the cell
                             paddingLeft: "var(--space-c)",
                             paddingRight: "calc(var(--space-c) - 5px)",
                             height: 36,
@@ -705,8 +705,8 @@ function PreviewBoxes_main_modules({
                             flexDirection: "column",
                             position: "absolute",
                             zIndex: 100,
-                            minWidth: "115px",
-                            maxWidth: "122px",
+                            minWidth: "140px",  // Changed to match button width
+                            maxWidth: "145px",  // Changed to match button width
                             width: "100%",
                             backgroundColor: "var(--color-Grey3)",
                             borderRadius: "var(--elemtns-round-corner-medium)",


### PR DESCRIPTION
## Summary
This PR fixes the alignment issue with the Tags dropdown button in the Modules table header.

## Changes Made
- Updated the Tags dropdown button width from `115-122px` to `140-145px` to better fill the 150px column
- Updated the dropdown menu width to match the button width for consistent alignment
- The button now properly aligns with the tags content in the column below it

## Visual Impact
- The Tags dropdown button in the table header now properly fills its column width
- Better visual alignment between the header button and the column content
- Maintains center alignment for both the button and the tags content

## Technical Details
- Modified `src/Components/PreviewBox_main.js`
- Changed button `minWidth` from `115px` to `140px`
- Changed button `maxWidth` from `122px` to `145px`
- Updated dropdown menu dimensions to match

This ensures the Tags dropdown button visually aligns with the column content underneath it, improving the overall table appearance.